### PR TITLE
Changed code to use unique_ptr instead of auto_ptr

### DIFF
--- a/ticpp.cpp
+++ b/ticpp.cpp
@@ -26,6 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "ticpprc.h"
 #include "tinyxml.h"
 #include <sstream>
+#include <memory>
 
 using namespace ticpp;
 
@@ -716,14 +717,14 @@ StylesheetReference* Node::ToStylesheetReference() const
 	return temp;
 }
 
-std::auto_ptr< Node > Node::Clone() const
+std::unique_ptr< Node > Node::Clone() const
 {
 	TiXmlNode* node = GetTiXmlPointer()->Clone();
 	if ( 0 == node )
 	{
 		TICPPTHROW( "Node could not be cloned" );
 	}
-	std::auto_ptr< Node > temp( NodeFactory( node, false, false ) );
+	std::unique_ptr< Node > temp( NodeFactory( node, false, false ) );
 
 	// Take ownership of the memory from TiXml
 	temp->m_impRC->InitRef();

--- a/ticpp.h
+++ b/ticpp.h
@@ -975,13 +975,13 @@ namespace ticpp
 		/**
 		Create an exact duplicate of this node and return it.
 
-		@note Using auto_ptr to manage the memory declared on the heap by TiXmlNode::Clone.
+		@note Using unique_ptr to manage the memory declared on the heap by TiXmlNode::Clone.
 		@code
 		// Now using clone
 		ticpp::Document doc( "C:\\Test.xml" );
 		ticpp::Node* sectionToClone;
 		sectionToClone = doc.FirstChild( "settings" );
-		std::auto_ptr< ticpp::Node > clonedNode = sectionToClone->Clone();
+		std::unique_ptr< ticpp::Node > clonedNode = sectionToClone->Clone();
 		// Now you can use the clone.
 		ticpp::Node* node2 = clonedNode->FirstChildElement()->FirstChild();
 		...
@@ -989,7 +989,7 @@ namespace ticpp
 		@endcode
 		@return Pointer the duplicate node.
 		*/
-		std::auto_ptr< Node > Clone() const;
+		std::unique_ptr< Node > Clone() const;
 
 		/**
 		Accept a hierchical visit the nodes in the TinyXML DOM.


### PR DESCRIPTION
In the codebase I am looking at this change worked.  But this got rid of a tonne of warning and mostly they have the same semantics, minus copy/move construction/assignment