### PR TITLE
Use C++11's unique_ptr instead of auto_ptr

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -26,6 +26,7 @@ solution "TinyXML++"
 	targetdir "lib"
 	implibdir "lib"
 	configurations { "Debug", "Release" }
+	buildoptions { "-std=c++14" }
 
 -- This is for including other Premake scripts.
 dofile( "ticpp4.lua" )

--- a/tests/mocks/TicppMock.hh
+++ b/tests/mocks/TicppMock.hh
@@ -23,7 +23,7 @@ namespace ticpp
 			MOCK_METHOD1( GetValue, void ( std::string* ) );
 			MOCK_METHOD1( SetIntText, void ( const unsigned int ) );
 			MOCK_METHOD1( RemoveChild, void ( Node* ) );
-			MOCK_CONST_METHOD0( Clone, const Node& ( void ) );		//This is done because auto_ptr's copy constructor is declared explicit and generates a compiler error inside googlemock.
+			MOCK_CONST_METHOD0( Clone, const Node& ( void ) );		//This is done because unique_ptr's copy constructor is deleted and generates a compiler error inside googlemock.
 			MOCK_CONST_METHOD0( ToElement, Element*( void ) );
 			MOCK_CONST_METHOD0( NoChildren, bool ( void ) );
 			MOCK_CONST_METHOD0( FirstChild, Node*( void ) );
@@ -41,7 +41,7 @@ namespace ticpp
 
 		struct Node : public StrictMock< NodeBase >
 		{
-			//This is the work around for the Clone method not returning auto_ptr.
+			//This is the work around for the Clone method not returning unique_ptr.
 			const Node* release( void ) const
 			{
 				return this;

--- a/ticpp.cpp
+++ b/ticpp.cpp
@@ -716,14 +716,14 @@ StylesheetReference* Node::ToStylesheetReference() const
 	return temp;
 }
 
-std::auto_ptr< Node > Node::Clone() const
+std::unique_ptr< Node > Node::Clone() const
 {
 	TiXmlNode* node = GetTiXmlPointer()->Clone();
 	if ( 0 == node )
 	{
 		TICPPTHROW( "Node could not be cloned" );
 	}
-	std::auto_ptr< Node > temp( NodeFactory( node, false, false ) );
+	std::unique_ptr< Node > temp( NodeFactory( node, false, false ) );
 
 	// Take ownership of the memory from TiXml
 	temp->m_impRC->InitRef();
@@ -1093,11 +1093,11 @@ void TiCppRC::DeleteSpawnedWrappers()
 	}
 	m_spawnedWrappers.clear();
 }
-		
+
 TiCppRC::~TiCppRC()
-{	
+{
 	DeleteSpawnedWrappers();
-	
+
 	// Set pointer held by reference counter to NULL
 	this->m_tiRC->Nullify();
 

--- a/ticpp.h
+++ b/ticpp.h
@@ -44,7 +44,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * - added ticppapi.h include and TICPP_API dll-interface to support building DLL using VS200X
  */
- 
+
 #ifndef TIXML_USE_TICPP
 	#define TIXML_USE_TICPP
 #endif
@@ -975,13 +975,13 @@ namespace ticpp
 		/**
 		Create an exact duplicate of this node and return it.
 
-		@note Using auto_ptr to manage the memory declared on the heap by TiXmlNode::Clone.
+		@note Using unique_ptr to manage the memory declared on the heap by TiXmlNode::Clone.
 		@code
 		// Now using clone
 		ticpp::Document doc( "C:\\Test.xml" );
 		ticpp::Node* sectionToClone;
 		sectionToClone = doc.FirstChild( "settings" );
-		std::auto_ptr< ticpp::Node > clonedNode = sectionToClone->Clone();
+		std::unique_ptr< ticpp::Node > clonedNode = sectionToClone->Clone();
 		// Now you can use the clone.
 		ticpp::Node* node2 = clonedNode->FirstChildElement()->FirstChild();
 		...
@@ -989,7 +989,7 @@ namespace ticpp
 		@endcode
 		@return Pointer the duplicate node.
 		*/
-		std::auto_ptr< Node > Clone() const;
+		std::unique_ptr< Node > Clone() const;
 
 		/**
 		Accept a hierchical visit the nodes in the TinyXML DOM.


### PR DESCRIPTION
Removes deprecation warnings with newer compilers.