### PR TITLE
Fixes #61

### DIFF
--- a/ticpp.cpp
+++ b/ticpp.cpp
@@ -788,6 +788,7 @@ Document::Document()
 Document::Document( TiXmlDocument* document )
 : NodeImp< TiXmlDocument >( document )
 {
+	m_impRC->InitRef();
 }
 
 Document::Document( const char* documentName )


### PR DESCRIPTION
This appears to fix the memory leak caused by calling `GetDocument()` on a `Document` or having a `Document` returned by a call to `Parent()` on a node, as explained in #61.

I don't know whether it has other, undesired effects.