### PR TITLE
Update minimum CMake version to 3.7.2 (Debian Stretch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/*build*
+*.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(ticpp)
-cmake_minimum_required(VERSION 2.8.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.7.2)
+project(ticpp LANGUAGES CXX)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_DEBUG_POSTFIX "d")


### PR DESCRIPTION
This update removes a warning about a too old version of CMake that will be not supported in a future version.
- The new version matches the one in current Debian Stretch (old stable).
- A `.gitignore` file was added for usual build directories and CMake user files used by QtCreator IDE, which has CMake direct support.
- The `project` command was moved below `cmake_minimum_required`, see the [docs](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) also about the `FATAL_ERROR` removal.